### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[![Build Status](https://travis-ci.org/dls-controls/dls_pi_piezo_scan.svg?branch=master)](https://travis-ci.org/dls-controls/dls_pi_piezo_scan)
+[![Build Status](https://travis-ci.org/DiamondLightSource/dls_pi_piezo_scan.svg?branch=master)](https://travis-ci.org/DiamondLightSource/dls_pi_piezo_scan)


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/dls_pi_piezo_scan` using https://gitlab.diamond.ac.uk/github/github-scripts